### PR TITLE
VRCFlowManagerVRCが文字化けしているのを無視する

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -20,7 +20,7 @@ class Program {
 			Match match;
 
 			while ((lineString = reader.ReadLine()) != null) {
-				if (!lineString.Contains("[VRCFlowManagerVRC] Destination set: "))
+				if (!lineString.Contains("Destination set: "))
 					continue;
 
 				match = instanceRegex.Match(lineString);


### PR DESCRIPTION
`VRCFlowManagerVRC`を含む`[]`で囲まれているやつがめちゃくちゃ文字化けしていて困ったので．
それ以降は無事なのでとりあえず`Destination set:`だけ見れば機能する(最悪だが)．